### PR TITLE
PLANET-2574: IdeaPush: Handbook sidebar broken - Dots on screen

### DIFF
--- a/css/ideapush.css
+++ b/css/ideapush.css
@@ -24,3 +24,7 @@ footer.author-block {
     width: 14px;
     margin-right: 3px;
 }
+
+ul.dynamic-idea-listing {
+    list-style: none;
+}


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-2574

Fixes this error:

<img width="236" alt="captura de pantalla 2018-11-29 a la s 08 13 07" src="https://user-images.githubusercontent.com/340766/49218730-05173200-f3b0-11e8-9d7d-3e68ad4b3d57.png">
