### PR TITLE
PLANET-2576 IdeaPush: fix attachement image (Not resized)

### DIFF
--- a/css/ideapush.css
+++ b/css/ideapush.css
@@ -47,3 +47,7 @@ ul.dynamic-idea-listing li::after {
     opacity: 1;
     position: relative;
 }
+
+.msg img {
+    max-width: 100%;
+}


### PR DESCRIPTION
- max-width put in to prevent image in attachment dialog from overflowing past container