### PR TITLE
PLANET-4147: Enable "Code" and "Preformatted" blocks in Handbook only

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -47,3 +47,39 @@ function enqueue_child_styles() {
 
 	wp_enqueue_style( 'child-style', get_stylesheet_directory_uri() . '/style.css', [], $css_creation );
 }
+
+const BLOCK_WHITELIST = [
+	'post' => [
+		// E.g.: 'gpnl/blockquote'.
+		'core/code',
+		'core/preformatted',
+	],
+	'page' => [
+		'core/code',
+		'core/preformatted',
+	],
+];
+
+const BLOCK_BLACKLIST = [
+	'post' => [
+		// E.g.: 'planet4-blocks/gallery' or 'core/quote'.
+	],
+	'page' => [],
+];
+
+function set_child_theme_allowed_block_types( $allowed_block_types, $post ) {
+	if ( ! empty( BLOCK_WHITELIST[ $post->post_type ] )) {
+		$allowed_block_types = array_merge( $allowed_block_types, BLOCK_WHITELIST[$post->post_type] );
+	}
+
+	if ( ! empty( BLOCK_BLACKLIST[ $post->post_type ] )) {
+		$allowed_block_types = array_filter( $allowed_block_types, function ( $element ) use ( $post ) {
+			return !in_array( $element, BLOCK_BLACKLIST[ $post->post_type ] );
+		} );
+	}
+
+	// array_values is required as array_filter removes indexes from the array.
+	return array_values($allowed_block_types);
+}
+
+add_filter( 'allowed_block_types', 'set_child_theme_allowed_block_types', 15, 2 );


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-4147

This also serves as a working example for: https://jira.greenpeace.org/browse/PLANET-4217