### PR TITLE
PLANET-5000: Rollover color of primary navigation (footer and header) links is wrong

### DIFF
--- a/css/footer.css
+++ b/css/footer.css
@@ -12,7 +12,14 @@
   color: var(--blue);
 }
 
-.footer-social-media a:hover {
+.site-footer .container .footer-links a:hover,
+.site-footer .container .footer-links-secondary a:hover,
+.site-footer .container .gp-year a:hover,
+.site-footer .container .copyright-text a:hover {
+  color: var(--handbook-footer-links-hover);
+}
+
+.site-footer .container .footer-social-media a:hover {
   color: var(--blue);
   opacity: 0.8;
 }

--- a/css/variables.css
+++ b/css/variables.css
@@ -11,4 +11,6 @@
 
   --sidebar-blue: #01223d;
   --sidebar-width: 250px;
+
+  --handbook-footer-links-hover: #2980B9;
 }


### PR DESCRIPTION
Adding a specific hover color for the handbook's footer.

Ref: https://jira.greenpeace.org/browse/PLANET-5000