### PR TITLE
Fix navigation sidebar line-height

### DIFF
--- a/css/navigation.css
+++ b/css/navigation.css
@@ -51,7 +51,8 @@
     padding: 0;
   }
 
-  li.nav-child .nav-link {
+  li.nav-child .nav-link,
+  li.nav-item {
     text-transform: none;
     line-height: 1.5;
     font-size: .8rem;


### PR DESCRIPTION
The navigation side bar line-height is currently way too big (see https://planet4.greenpeace.org/), this should fix it!