### PR TITLE
Replace the Greenpeace logo

### DIFF
--- a/templates/sidebar.twig
+++ b/templates/sidebar.twig
@@ -1,7 +1,7 @@
 {% block sidebar %}
 	<nav id="sidebar" class="sidebar-navigation">
-		<a class="site-logo" href="{{ data_nav_bar.home_url }}">
-			<img src="{{ data_nav_bar.images }}gp-logo.svg" alt="Greenpeace"/>
+		<a class="site-logo" href="{{ data_nav_bar.home_url }}/handbook">
+			<img src="{{ data_nav_bar.images }}planet4.png" alt="Planet 4 Handbook"/>
 		</a>
 		<ul class="list-unstyled">
 			{% for key,item in navbar_menu.get_items %}


### PR DESCRIPTION
This commit replaces the Greenpeace logo on Planet 4 Handbook.

Ref: [Replace the "Greenpeace" logo](https://github.com/greenpeace/planet4/issues/160)