### PR TITLE
PLANET-6423 Add a Handbook production updates notice banner on fronte…

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -87,3 +87,16 @@ function set_child_theme_allowed_block_types( $allowed_block_types, $post ) {
 }
 
 add_filter( 'allowed_block_types', 'set_child_theme_allowed_block_types', 15, 2 );
+
+/**
+ * Notice banner for production updates on each admin page.
+ *
+ * @return string
+ */
+function general_admin_notice(){
+	echo '<div class="notice notice-warning is-dismissible">
+		<p>The P4 team is currently running some changes to the site. Please be aware that you might be redirected to some other sources on the world wide web or you will find the content you are looking for in another format. If you notice anything missing, please let us know in the <b><a href="https://app.slack.com/client/T013PTEK4AV/C014UMRC4AJ" target="_blank">p4-general</a></b> Slack channel. Thank you!</p>
+	</div>';
+}
+
+add_action('admin_notices', 'general_admin_notice');

--- a/style.css
+++ b/style.css
@@ -35,3 +35,15 @@ div.page-header {
 h1, h2, h3, h4, h5, h6.page-template {
   font-family: Roboto, sans-serif;
 }
+
+/* Notice banner for production updates */
+.notice-banner {
+  margin-top: 80px;
+  margin-bottom: 0;
+}
+
+@media only screen and (max-width: 992px) {
+  .notice-banner {
+    margin-top: 54px
+  }
+}

--- a/templates/sidebar.twig
+++ b/templates/sidebar.twig
@@ -1,4 +1,5 @@
 {% block sidebar %}
+	<p class="has-orange-hover-color has-yellow-background-color has-text-color has-background notice-banner">The P4 team is currently running some changes to the site. Please be aware that you might be redirected to some other sources on the world wide web or you will find the content you are looking for in another format. If you notice anything missing, please let us know in the <b><a href="https://app.slack.com/client/T013PTEK4AV/C014UMRC4AJ" target="_blank">p4-general</a></b> Slack channel. Thank you!</p>
 	<nav id="sidebar" class="sidebar-navigation">
 		<a class="site-logo" href="{{ data_nav_bar.home_url }}/handbook">
 			<img src="{{ data_nav_bar.images }}planet4.png" alt="Planet 4 Handbook"/>


### PR DESCRIPTION
…nd and backend

Ref. https://jira.greenpeace.org/browse/PLANET-6423

Testing:
- Checkout the handbook child theme on local along with planet-6423 branch
- On frontend and backend of handbook child theme, the notice banner should be visible.

eg.
![image](https://user-images.githubusercontent.com/5357471/138070361-26761fc1-88d4-4440-867f-2189f5856b98.png)
![image](https://user-images.githubusercontent.com/5357471/138070402-e32c78b2-e780-46f0-b4bb-c8cd620d1fa8.png)
