### PR TITLE
Reduce highlight vertical padding

### DIFF
--- a/style.css
+++ b/style.css
@@ -146,6 +146,10 @@ h1, h2, h3, h4, h5, h6.page-template {
   background-color: #FFF6BD;
 }
 
+.mark, mark {
+  padding: 0 .2em;
+}
+
 :root {
   --nav-link--color: #fff;
   --nav-link--visited--color: #fff;


### PR DESCRIPTION
Reduce vertical padding to avoid highlight going over other lines decorations

_Before_
![Screenshot from 2023-08-31 12-39-37](https://github.com/greenpeace/planet4-child-theme-handbook/assets/617346/7fe8a18a-34b2-499a-b90f-f04a0759015c)

_After_
![Screenshot from 2023-08-31 12-39-07](https://github.com/greenpeace/planet4-child-theme-handbook/assets/617346/aa1e56b4-706d-4aef-8f3e-d5787abc5b77)
