### PR TITLE
Fix templates for Timber upgrade

### DIFF
--- a/templates/sidebar.twig
+++ b/templates/sidebar.twig
@@ -31,9 +31,9 @@
 			{% for key,item in navbar_menu.get_items %}
 				<li class="nav-item {{ class_name }} {{ item == item.current ? 'active' : '' }}">
 					<a class="nav-link {% if item.classes %}{{ item.classes|join(' ')}}{% endif %}" href="{{ item.link }}" {% if item.target %}target="{{ item.target }}"{% endif %}>{{ item.title }}</a>
-					{% if item.get_children %}
+					{% if item.children %}
 						<ul class="list-unstyled">
-							{% for child in item.get_children %}
+							{% for child in item.children %}
 								<li class="nav-item nav-child {{ child == child.current ? 'active' : '' }}">
 									<a class="nav-link {% if child.classes %}{{ child.classes|join(' ')}}{% endif %}" href="{{ child.link }}" {% if child.target %}target="{{ child.target }}"{% endif %}>{{ child.title }}</a>
 								</li>


### PR DESCRIPTION
This PR fixes below.
```
Notice: [ Timber ] {{ item.get_children }} is deprecated since Timber version 2.0.0! Use {{ item.children }} instead. in /var/www/html/wp-content/vendor/timber/timber/src/Helper.php on line 462
```
-------------
**Testing:**

To reproduce the above error locally, please follow the steps below:
- Set up a handbook environment locally using `npm run env:install handbook`
- Ensure that `WP_DEBUG` is set to `true`
- When browsing the site, you should be able to see the above error, or you can check the `planet4/debug.log` file for it