### PR TITLE
Add filter to allow file modifications for the LoCo plugin

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -231,3 +231,21 @@ function planet4_get_announcements() {
 		'last_updated' => get_option('planet4_announcements_last_updated'),
 	];
 }
+
+/**
+ * Define a context value to allow translation file mods
+ */
+add_filter('loco_file_mod_allowed_context', function(){
+    return 'loco_file_mod_context';
+} );
+
+/**
+ * Allow file mods for the LoCo plugin.
+ * As long as the current user is at least an Editor.
+ */
+add_filter('file_mod_allowed', function($default,$context){
+    if('loco_file_mod_context' === $context){
+        return current_user_can('edit_others_posts');
+    }
+    return $default;
+}, 10, 2);


### PR DESCRIPTION
### Summary

Historically we build a different docker image for the Handbook. We do that to apply two additional changes. This PR addresses the [first one](https://github.com/greenpeace/planet4-docker/blob/v0.10.654/src/planet-4-151612/handbook/templates/Dockerfile.in#L3). 

LoCo plugin can't commit translation files if DISALLOW_FILE_MODS is set to true. But there is a way to override that using the `file_mod_allowed` filter in combination with `loco_file_mod_allowed_context`. In addition, we can also check for the current user to at at least an Editor, since this the permissions configuration we currently have for translations (see _LoCo Translate > Settings > Site Options_).

